### PR TITLE
メインのページではMathjaxは使わないため、記事ページのときだけMathjaxを読み込むように修正

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
 >
   <head>
     {{ partial "head.html" . }}
+    {{ block "head" . }}{{end}}
   </head>
   <body class="flex min-h-screen w-full flex-col">
     <header class="z-10 flex flex-none justify-center">
@@ -18,9 +19,7 @@
       {{ partial "footer.html" . }}
     </footer>
     {{ partialCached "js.html" . }}
-    {{ if .Param "math" }}
-      {{ partialCached "math.html" . }}
-    {{ end }}
+    {{ block "loadjs" . }}{{ end }}
     {{ template "_internal/google_analytics.html" . }}
   </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -74,3 +74,9 @@
     </div>
   </div>
 {{ end }}
+
+{{ define "loadjs" }}
+  {{ if or .Page.Params.math .Site.Params.math }}
+    {{ partialCached "math.html" . }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
related to #35 