### PR TITLE
ファイルのリンクが壊れる問題を修正（staticフォルダの内容が反映されない）

### DIFF
--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -16,6 +16,12 @@ theme = "hugo_theme_windy"
     extended = true
     min = "0.116.0"
   [[module.mounts]]
+    source = 'assets'
+    target = 'assets'
+  [[module.mounts]]
+    source = 'static'
+    target = 'static'
+  [[module.mounts]]
     source = '../node_modules/mathjax' # Specify a proper directory for node_modules.
     target = 'assets/mathjax'
   [[module.mounts]]


### PR DESCRIPTION
Related to #57 

fa01b889から62cf6f1f6be25fedd07d28d7ace45d3764265edbへの変更でstaticのファイルがうまくレンダリングできなかった。